### PR TITLE
Fix $getter mixup in sluggable behaviour generator

### DIFF
--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -330,9 +330,9 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
         ->prune(\$this)";
 
         if ($this->getParameter('scope_column')) {
-            $getter = 'get' . $this->getColumnForParameter('scope_column')->getPhpName();
+            $scope_column = $this->getColumnForParameter('scope_column')->getPhpName();
             $script .= "
-            ->filterBy('{$this->getColumnForParameter('scope_column')->getPhpName()}', \$this->{$getter}())";
+            ->filterBy('{$scope_column}', \$this->get{$scope_column}())";
         }
         // watch out: some of the columns may be hidden by the soft_delete behavior
         if ($this->table->hasBehavior('soft_delete')) {


### PR DESCRIPTION
When a `scope_column` is present in the config of the behaviour the `$getter` gets overwritten which breaks things.